### PR TITLE
Switch to more lightweight format

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,19 @@
 name = "PlutoSplitter"
 uuid = "26593b87-58e3-4a81-8553-1b48117f317a"
 authors = ["Bruno Ploumhans <13494793+Technici4n@users.noreply.github.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "1.10"
+Logging = "1.10"
 Pluto = "0.19.47"
 Test = "1.10.0"
 TestItemRunner = "1"
+julia = "1.10"
 
 [extras]
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"

--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@ so that a statement and a solution notebook can be generated from the same sourc
 
 With this package, you can write a notebook that contains two cells, for example:
 ```jl
-#= begin statement =#
+### split: statement
 # Fill in your code here, by replacing nothing
 # with a function that adds 42 to x
 f(x) = nothing
-#= end statement =#
 ```
 and
 ```jl
-#= begin solution =#
+### split: solution
 f(x) = x + 42
-#= end solution =#
 ```
 (You will have to disable one of them to fit both in the notebook.)
 
@@ -31,3 +29,11 @@ split_notebook("path/to/your_notebook.jl", "statement")
 # Generate path/to/your_notebook_solution.jl
 split_notebook("path/to/your_notebook.jl", "solution")
 ```
+
+## Format details
+Cells must contain `### split: XXX` in the first line, where `XXX` can be:
+- `statement`
+- `solution`
+- `statement,folded`
+- `solution,folded`
+The first two require the cell not to be folded, the last two require the cell to be folded.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ so that a statement and a solution notebook can be generated from the same sourc
 
 With this package, you can write a notebook that contains two cells, for example:
 ```jl
-### split: statement
+# split: statement
 # Fill in your code here, by replacing nothing
 # with a function that adds 42 to x
 f(x) = nothing
 ```
 and
 ```jl
-### split: solution
+# split: solution
 f(x) = x + 42
 ```
 (You will have to disable one of them to fit both in the notebook.)
@@ -31,7 +31,7 @@ split_notebook("path/to/your_notebook.jl", "solution")
 ```
 
 ## Format details
-Cells must contain `### split: XXX` in the first line, where `XXX` can be:
+Cells must contain `# split: XXX` in the first line, where `XXX` can be:
 - `statement`
 - `solution`
 - `statement,folded`

--- a/examples/simple.jl
+++ b/examples/simple.jl
@@ -12,16 +12,14 @@ f(10)
 # ╔═╡ 02f2e7c5-2f0d-4fee-a7f3-27b088411aa6
 # ╠═╡ disabled = true
 #=╠═╡
-#= begin solution =#
+### split: solution
 f(x) = x + 42
-#= end solution =#
   ╠═╡ =#
 
 # ╔═╡ d9e9f737-6c87-4935-8252-8d576c195ced
 #=╠═╡
-#= begin statement =#
+### split: statement
 f(x) = nothing
-#= end statement =#
   ╠═╡ =#
 
 # ╔═╡ Cell order:

--- a/examples/simple.jl
+++ b/examples/simple.jl
@@ -9,17 +9,17 @@ using InteractiveUtils
 f(10)
   ╠═╡ =#
 
+# ╔═╡ d9e9f737-6c87-4935-8252-8d576c195ced
+#=╠═╡
+# split: statement
+f(x) = nothing
+  ╠═╡ =#
+
 # ╔═╡ 02f2e7c5-2f0d-4fee-a7f3-27b088411aa6
 # ╠═╡ disabled = true
 #=╠═╡
-### split: solution
+# split: solution
 f(x) = x + 42
-  ╠═╡ =#
-
-# ╔═╡ d9e9f737-6c87-4935-8252-8d576c195ced
-#=╠═╡
-### split: statement
-f(x) = nothing
   ╠═╡ =#
 
 # ╔═╡ Cell order:

--- a/examples/simple_statement.jl
+++ b/examples/simple_statement.jl
@@ -6,9 +6,7 @@ using InteractiveUtils
 
 # ╔═╡ d9e9f737-6c87-4935-8252-8d576c195ced
 #=╠═╡
-#= begin statement =#
 f(x) = nothing
-#= end statement =#
   ╠═╡ =#
 
 # ╔═╡ 86cb479c-6bd1-4703-950e-544a877d9023

--- a/src/PlutoSplitter.jl
+++ b/src/PlutoSplitter.jl
@@ -3,8 +3,8 @@ module PlutoSplitter
 using Logging
 import Pluto
 
-SPLIT_REGEX_MULTILINE = r"^###\s*split:\s*(.*)$"m
-SPLIT_REGEX = r"^###\s*split:\s*(.*)\n"
+SPLIT_REGEX_MULTILINE = r"^#\s*split:\s*(.*)$"m
+SPLIT_REGEX = r"^#\s*split:\s*(.*)\n"
 
 struct SplitTag
     kind::String

--- a/test/cell_identification.jl
+++ b/test/cell_identification.jl
@@ -1,19 +1,17 @@
-@testitem "Test begin finding" begin
-    import PlutoSplitter
+@testitem "Test split finding" begin
+    import PlutoSplitter: parse_split_tag, SplitTag
 
-    @test PlutoSplitter.begin_occursin("#= begin statement =# f(10)", "statement") == true
-    @test PlutoSplitter.begin_occursin("f(10)", "statement") == false
-    # Begin should be in the beginning, ignoring whitespace
-    @test PlutoSplitter.begin_occursin("   #= begin statement =# f(10)", "statement") == true
-    @test_throws "not at the beginning of the cell" PlutoSplitter.begin_occursin("f(10) #= begin statement =#", "statement")
-end
-
-@testitem "Test end finding" begin
-    import PlutoSplitter
-
-    @test PlutoSplitter.end_occursin("f(10) #= end statement =#", "statement") == true
-    @test PlutoSplitter.end_occursin("f(10)", "statement") == false
-    # End should be in the end, ignoring whitespace
-    @test PlutoSplitter.end_occursin("f(10)   #= end statement =#   ", "statement") == true
-    @test_throws "not at the end of the cell" PlutoSplitter.end_occursin("#= end statement =# f(10)", "statement")
+    # Test statement tag with various spacing
+    @test parse_split_tag("### split: statement\n") == SplitTag("statement", false)
+    @test parse_split_tag("###split:statement\n") == SplitTag("statement", false)
+    # Test other tag types
+    @test parse_split_tag("### split: solution\n") == SplitTag("solution", false)
+    @test parse_split_tag("### split: statement,folded\n") == SplitTag("statement", true)
+    @test parse_split_tag("### split: solution,folded\n") == SplitTag("solution", true)
+    # Test common errors
+    @test_throws "Unknown split: tag: unknown" parse_split_tag("### split: unknown\n")
+    @test_throws "should be on the first line" parse_split_tag("f(10)\n### split: statement")
+    @test_throws "should be on the first line" parse_split_tag("### split: statement")
+    # trailing whitespace is currently not allowed
+    @test_throws "Unknown split: tag: statement   " parse_split_tag("###   split: statement   \n")
 end

--- a/test/cell_identification.jl
+++ b/test/cell_identification.jl
@@ -2,16 +2,16 @@
     import PlutoSplitter: parse_split_tag, SplitTag
 
     # Test statement tag with various spacing
-    @test parse_split_tag("### split: statement\n") == SplitTag("statement", false)
-    @test parse_split_tag("###split:statement\n") == SplitTag("statement", false)
+    @test parse_split_tag("# split: statement\n") == SplitTag("statement", false)
+    @test parse_split_tag("#split:statement\n") == SplitTag("statement", false)
     # Test other tag types
-    @test parse_split_tag("### split: solution\n") == SplitTag("solution", false)
-    @test parse_split_tag("### split: statement,folded\n") == SplitTag("statement", true)
-    @test parse_split_tag("### split: solution,folded\n") == SplitTag("solution", true)
+    @test parse_split_tag("# split: solution\n") == SplitTag("solution", false)
+    @test parse_split_tag("# split: statement,folded\n") == SplitTag("statement", true)
+    @test parse_split_tag("# split: solution,folded\n") == SplitTag("solution", true)
     # Test common errors
-    @test_throws "Unknown split: tag: unknown" parse_split_tag("### split: unknown\n")
-    @test_throws "should be on the first line" parse_split_tag("f(10)\n### split: statement")
-    @test_throws "should be on the first line" parse_split_tag("### split: statement")
+    @test_throws "Unknown split: tag: unknown" parse_split_tag("# split: unknown\n")
+    @test_throws "should be on the first line" parse_split_tag("f(10)\n# split: statement")
+    @test_throws "should be on the first line" parse_split_tag("# split: statement")
     # trailing whitespace is currently not allowed
-    @test_throws "Unknown split: tag: statement   " parse_split_tag("###   split: statement   \n")
+    @test_throws "Unknown split: tag: statement   " parse_split_tag("#   split: statement   \n")
 end


### PR DESCRIPTION
New format at a glance:
```jl
# split: statement
f(x) = nothing
```

Closes #1 with the new format.
Closes #2 and #3 by relaxing the checks.
Closes #4 by allowing `,folded` in the tag.