### PR TITLE
Add flag to disable the strict error checking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoSplitter"
 uuid = "26593b87-58e3-4a81-8553-1b48117f317a"
 authors = ["Bruno Ploumhans <13494793+Technici4n@users.noreply.github.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -10,7 +10,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Logging = "1.10"
-Pluto = "0.19.47"
+Pluto = "0.19.47,0.20"
 Test = "1.10.0"
 TestItemRunner = "1"
 julia = "1.10"

--- a/src/PlutoSplitter.jl
+++ b/src/PlutoSplitter.jl
@@ -67,7 +67,7 @@ Split a notebook file.
 - type: Type of splitting to perform.
         Can be "check" to only perform some sanity checks, "statement" or "solution".
 """
-function split_notebook(notebookfile, type::String)
+function split_notebook(notebookfile, type::String; strict_errors=true)
     @assert type ∈ ["check", "statement", "solution"]
 
     statements = Int[]
@@ -79,7 +79,7 @@ function split_notebook(notebookfile, type::String)
     for (i, cell) in enumerate(nb.cells)
         tag = parse_split_tag(cell.code)
         if isnothing(tag)
-            if was_statement
+            if strict_errors && was_statement
                 error("Expected statement or solution cell to follow statement cell $(cell.code).")
             else
                 was_enabled = missing
@@ -94,11 +94,11 @@ function split_notebook(notebookfile, type::String)
         elseif is_statement != was_statement
             was_enabled = !was_enabled
         end
-        check_enabled(was_enabled, cell)
+        strict_errors && check_enabled(was_enabled, cell)
         push!(is_statement ? statements : solutions, i)
         was_statement = is_statement
     end
-    if was_statement
+    if strict_errors && was_statement
         error("Last cell was a statement cell, expected a solution cell afterwards.")
     end
 


### PR DESCRIPTION
Hi, the more compact tagging is much easier to use!

However, it seems like our notebooks seem to violate a lot of your implicit checks. I added a keyword argument `strict_errors=true` to the `split_notebook` function that optionally disables these checks. The default behaviour does not change.

I also increased the Pluto compat to 0.20. I did not encounter any errors and your tests are still passing