### PR TITLE
Add keyword argument output_filename

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoSplitter"
 uuid = "26593b87-58e3-4a81-8553-1b48117f317a"
 authors = ["Bruno Ploumhans <13494793+Technici4n@users.noreply.github.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/src/PlutoSplitter.jl
+++ b/src/PlutoSplitter.jl
@@ -63,11 +63,14 @@ export split_notebook
 """
 Split a notebook file.
 
-- notebookfile: File to split.
-- type: Type of splitting to perform.
+- `notebookfile`: File to split.
+- `type`: Type of splitting to perform.
         Can be "check" to only perform some sanity checks, "statement" or "solution".
+        
+Keyword arguments:
+- `output_filename`, Optional: The filename to save the processed notebook at, by default `type` is appended to the original filename. `output_filename` can also be a function with two arguments, which will be passed `notebookfile` and `type` and should return the new filename as a String.
 """
-function split_notebook(notebookfile, type::String)
+function split_notebook(notebookfile, type::String; output_filename::Union{String, Function, Nothing}=nothing)
     @assert type ∈ ["check", "statement", "solution"]
 
     statements = Int[]
@@ -101,11 +104,16 @@ function split_notebook(notebookfile, type::String)
         delete_cell_at(nb, i)
     end
 
-    basename, ext = splitext(notebookfile)
-    splitnotebookfile = "$(basename)_$type$ext"
-    Pluto.save_notebook(nb, splitnotebookfile)
+    if isnothing(output_filename)
+        basename, ext = splitext(notebookfile)
+        output_filename = "$(basename)_$type$ext"
+    elseif output_filename isa Function
+        output_filename = output_filename(notebookfile, type)
+    end
 
-    @info "Successfully split notebook to $(splitnotebookfile)."
+    Pluto.save_notebook(nb, output_filename)
+
+    @info "Successfully split notebook to $(output_filename)."
 end
 
 end # module PlutoSplitter


### PR DESCRIPTION
Adds some flexibility to the split_notebook function. Allows setting a custom output filename or a function that can process the input filename and type to result in an output filename (e.g. to put the split solution and statement notebooks in different subfolders)