### PR TITLE
Don't modify the source notebook

### DIFF
--- a/src/PlutoSplitter.jl
+++ b/src/PlutoSplitter.jl
@@ -76,7 +76,7 @@ function split_notebook(notebookfile, type::String; output_filename::Union{Strin
     statements = Int[]
     solutions = Int[]
 
-    nb = Pluto.load_notebook(notebookfile)
+    nb = Pluto.load_notebook(notebookfile; disable_writing_notebook_files=true)
 
     for (i, cell) in enumerate(nb.cells)
         tag = parse_split_tag(cell.code)


### PR DESCRIPTION
Unfortunately Pluto has some ordering inconsistency issues with disabled cells atm (they tend to be moved to the end of the notebook file sometimes). At least we can make sure that the source notebooks don't get modified unnecessarily when they're being split.